### PR TITLE
Return undefined when factory is not registered

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-ajax": "^2.4.1",
     "ember-cli": "2.12.0-beta.1",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.2",
@@ -39,8 +38,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
-    "ember-source": "^2.12.0-beta.1",
-    "ember-welcome-page": "^2.0.2",
+    "ember-source": "^2.11.0",
     "loader.js": "^4.1.0"
   },
   "engines": {

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -42,6 +42,13 @@ test('factoryFor exposes "raw" .class`', function(assert) {
   assert.ok(instance instanceof this.AppleFactory, 'creating an instance with .class results in `instanceof` match');
 });
 
+test('factoryFor returns undefined when factory is not registered', function(assert) {
+  let { owner } = this;
+  let Factory = owner.factoryFor('fruit:orange');
+
+  assert.equal(Factory, undefined, 'factory is undefined');
+});
+
 if (typeof Proxy !== 'undefined') {
   test('setting properties on Factory results in assertion', function(assert) {
     let { owner } = this;

--- a/tests/unit/utils/factory-for-test.js
+++ b/tests/unit/utils/factory-for-test.js
@@ -21,6 +21,13 @@ test('factoryFor + .create results in objects with `owner`', function(assert) {
   assert.equal(getOwner(instance), owner, 'owner of instace created from factoryFor matches environment owner');
 });
 
+test('returns undefined if factory does not exist', function(assert) {
+  let owner = getOwner(this);
+  let Factory = owner.factoryFor('fruit:orange');
+
+  assert.equal(Factory, undefined, 'factory is undefined');
+});
+
 test('factoryFor exposes "raw" .class`', function(assert) {
   let owner = getOwner(this);
   let Factory = owner.factoryFor('fruit:apple');

--- a/vendor/ember-factory-for-polyfill/index.js
+++ b/vendor/ember-factory-for-polyfill/index.js
@@ -5,9 +5,14 @@
   var HAS_NATIVE_PROXY = typeof Proxy === 'function';
 
   function factoryFor(fullName) {
-    var FactoryManager = {
-      class: this._lookupFactory(fullName),
+    var factory = this._lookupFactory(fullName);
 
+    if (!factory) {
+      return;
+    }
+
+    var FactoryManager = {
+      class: factory,
       create: function() {
         return this.class.create.apply(this.class, arguments);
       }


### PR DESCRIPTION
This is makes it behave more like the implementation where if the factory is not registered, undefined is returned.

Currently an empty FactoryManager object is returned with an undefined class.